### PR TITLE
#68 - fix: 방 정보를 응답할 때, roomId를 포함하도록 수정

### DIFF
--- a/src/main/java/seoultech/capstone/menjil/domain/chat/application/RoomService.java
+++ b/src/main/java/seoultech/capstone/menjil/domain/chat/application/RoomService.java
@@ -95,6 +95,7 @@ public class RoomService {
                 String lastMessage = messageList.get(0).getMessage();
 
                 result.add(RoomListResponse.builder()
+                        .roomId(roomId)
                         .lastMessage(lastMessage)
                         .nickname(menteeNickname)
                         .build());
@@ -117,6 +118,7 @@ public class RoomService {
                 String lastMessage = messageList.get(0).getMessage();
 
                 result.add(RoomListResponse.builder()
+                        .roomId(roomId)
                         .lastMessage(lastMessage)
                         .nickname(mentorNickname)
                         .build());

--- a/src/main/java/seoultech/capstone/menjil/domain/chat/dto/response/RoomListResponse.java
+++ b/src/main/java/seoultech/capstone/menjil/domain/chat/dto/response/RoomListResponse.java
@@ -8,11 +8,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RoomListResponse {
 
+    private String roomId;
+
     private String nickname;
     private String lastMessage;
 
     @Builder
-    private RoomListResponse(String nickname, String lastMessage) {
+    private RoomListResponse(String roomId, String nickname, String lastMessage) {
+        this.roomId = roomId;
         this.nickname = nickname;
         this.lastMessage = lastMessage;
     }


### PR DESCRIPTION
### 완료된 작업  

- #68 에서, 방 정보를 응답할 때, roomId를 포함하도록 수정한 내용을 우선 PR(클라이언트측의 요청에 의한)